### PR TITLE
Remove Custom Labels Code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,15 @@ PATH
   remote: .
   specs:
     minitest-difftastic (0.1.1)
-      difftastic (~> 0.0.1)
+      difftastic (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     base64 (0.1.1)
-    difftastic (0.0.1-arm64-darwin)
-    difftastic (0.0.1-x86_64-linux)
+    difftastic (0.2.0-arm64-darwin)
+    difftastic (0.2.0-x86_64-linux)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     minitest (5.25.4)

--- a/lib/minitest/difftastic_plugin.rb
+++ b/lib/minitest/difftastic_plugin.rb
@@ -5,44 +5,21 @@ require "difftastic"
 # TODO: use refinements
 module Minitest
   module Assertions
-    MINIMUM_OFFSET = 29
-    TAB_WIDTH = 2
-
-    RED = "\e[91;1m"
-    GREEN = "\e[92;1m"
-    RESET = "\e[0m"
-
     DIFFER = ::Difftastic::Differ.new(
       color: :always,
       tab_width: TAB_WIDTH,
-      syntax_highlight: :off
+      syntax_highlight: :off,
+      left_label: "Expected",
+      right_label: "Actual"
     )
 
     alias diff_original diff
 
     def diff(exp, act)
-      diff = DIFFER.diff_objects(exp, act)
-      offset = actual_text_offset(diff.split("\n").first)
-
-      "\n#{RED}#{"Expected".ljust(offset)} #{GREEN}Actual#{RESET}\n#{diff}"
+      DIFFER.diff_objects(exp, act)
     rescue StandardError => e
       puts "Minitest::DiffTastic error: #{e.inspect} (#{e.backtrace[0]})"
       diff_original(exp, act)
-    end
-
-    private
-
-    def strip_ansi_formatting(string)
-      string.to_s.gsub(/\e\[[0-9;]*m/, "")
-    end
-
-    def actual_text_offset(line)
-      stripped_line = strip_ansi_formatting(line)
-      _lhs, rhs = stripped_line.split(/\s{#{TAB_WIDTH},}/, 2)
-
-      offset = stripped_line.index("#{" " * TAB_WIDTH}#{rhs}") + TAB_WIDTH - 1
-
-      [MINIMUM_OFFSET, offset].max
     end
   end
 end

--- a/lib/minitest/difftastic_plugin.rb
+++ b/lib/minitest/difftastic_plugin.rb
@@ -18,7 +18,7 @@ module Minitest
     def diff(exp, act)
       DIFFER.diff_objects(exp, act)
     rescue StandardError => e
-      puts "Minitest::DiffTastic error: #{e.inspect} (#{e.backtrace[0]})"
+      puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
       diff_original(exp, act)
     end
   end

--- a/lib/minitest/difftastic_plugin.rb
+++ b/lib/minitest/difftastic_plugin.rb
@@ -7,7 +7,7 @@ module Minitest
   module Assertions
     DIFFER = ::Difftastic::Differ.new(
       color: :always,
-      tab_width: TAB_WIDTH,
+      tab_width: 2,
       syntax_highlight: :off,
       left_label: "Expected",
       right_label: "Actual"

--- a/minitest-difftastic.gemspec
+++ b/minitest-difftastic.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "difftastic", "~> 0.0.1"
+  spec.add_dependency "difftastic", "~> 0.2"
 end


### PR DESCRIPTION
The code we used to print the labels was upstreamed to `difftastic-ruby` here: https://github.com/joeldrapper/difftastic-ruby/pull/1

So we can remove the code in `minitest-difftastic`.

~~We'll need to wait for a new release of `difftastic-ruby` though.~~