### PR TITLE
Suggest using `test` group when adding gem to `Gemfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Also works for Rails tests using `ActiveSupport::TestCase`.
 
 ## Installation
 
-Install the gem and add to the application's Gemfile by executing:
+Install the gem and add to the application's Gemfile `test` group by executing:
 
 ```shell
-bundle add minitest-difftastic
+bundle add minitest-difftastic --group=test
 ```
 
 If bundler is not being used to manage dependencies, install the gem by executing:


### PR DESCRIPTION
Nitpick but I'd like README to encourage better `Gemfile` hygiene by suggesting placing the gem into the `test` group so it doesn't get required in production & development