### PR TITLE
Update Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 
 gem "minitest", "~> 5.0"
 gem "rake", "~> 13.0"
-gem "rubocop", "~> 1.21"
+gem "rubocop", "~> 1.71"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,37 +8,35 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    base64 (0.1.1)
     difftastic (0.2.0-arm64-darwin)
     difftastic (0.2.0-x86_64-linux)
-    json (2.6.3)
+    json (2.9.1)
     language_server-protocol (3.17.0.3)
     minitest (5.25.4)
-    parallel (1.23.0)
-    parser (3.2.2.4)
+    parallel (1.26.3)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
-    rexml (3.2.6)
-    rubocop (1.56.2)
-      base64 (~> 0.1.1)
+    regexp_parser (2.10.0)
+    rubocop (1.71.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
-      parser (>= 3.2.1.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   arm64-darwin-24
@@ -48,7 +46,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   minitest-difftastic!
   rake (~> 13.0)
-  rubocop (~> 1.21)
+  rubocop (~> 1.71)
 
 BUNDLED WITH
    2.4.12


### PR DESCRIPTION
This, in turn, updates the `json` gem. I noticed that installed the required gems was failing on macOS due to a missing `gmkdir` utility. Updating the `json` gem (via Rubocop) resolves this error.