### PR TITLE
Refactor `diff` into `patches/` folder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/lib/minitest/difftastic.rb
+++ b/lib/minitest/difftastic.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
-require_relative "difftastic/version"
+require "difftastic"
 
-module Minitest
-  module Difftastic
-  end
+require "minitest/difftastic/version"
+
+module Minitest::Difftastic
+  DEFAULT_DIFFER = ::Difftastic::Differ.new(
+    color: :always,
+    tab_width: 2,
+    syntax_highlight: :off,
+    left_label: "Expected",
+    right_label: "Actual"
+  )
 end

--- a/lib/minitest/difftastic/patches/diff.rb
+++ b/lib/minitest/difftastic/patches/diff.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Minitest::Assertions
+  alias minitest_diff diff
+
+  def diff(exp, act)
+    ::Minitest::Difftastic::DEFAULT_DIFFER.diff_objects(exp, act)
+  rescue StandardError => e
+    puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
+    minitest_diff(exp, act)
+  end
+end

--- a/lib/minitest/difftastic_plugin.rb
+++ b/lib/minitest/difftastic_plugin.rb
@@ -1,25 +1,5 @@
 # frozen_string_literal: true
 
-require "difftastic"
+require "minitest/difftastic"
 
-# TODO: use refinements
-module Minitest
-  module Assertions
-    DIFFER = ::Difftastic::Differ.new(
-      color: :always,
-      tab_width: 2,
-      syntax_highlight: :off,
-      left_label: "Expected",
-      right_label: "Actual"
-    )
-
-    alias diff_original diff
-
-    def diff(exp, act)
-      DIFFER.diff_objects(exp, act)
-    rescue StandardError => e
-      puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
-      diff_original(exp, act)
-    end
-  end
-end
+require "minitest/difftastic/patches/diff"


### PR DESCRIPTION
This pull request 
* reorganizes the require statements
* defines the `DEFAULT_DIFFER` under the `Minitest::Difftastic` namespace
* extracts the patches into a dedicated `patches/` folder