### PR TITLE
Improve diff output for comparing `String`s with newlines

### DIFF
--- a/examples/assert_equal.rb
+++ b/examples/assert_equal.rb
@@ -39,5 +39,22 @@ module Examples
 
       assert_equal expected, actual
     end
+
+    def test_assert_equal_string_with_newlines
+      expected = <<~RUBY
+        class User < ApplicationRecord
+          has_many :posts
+        end
+      RUBY
+
+      actual = <<~RUBY
+        class User < ApplicationRecord
+          has_many :posts
+          ^^^^^^^^^^^^^^^ Rubocop::SomeRule Missing association to `organization`
+        end
+      RUBY
+
+      assert_equal expected, actual
+    end
   end
 end

--- a/examples/assert_equal.rb
+++ b/examples/assert_equal.rb
@@ -56,5 +56,17 @@ module Examples
 
       assert_equal expected, actual
     end
+
+    def test_assert_equal_string_with_newlines_on_one_side
+      expected = <<~RUBY
+        Hello
+
+        World
+      RUBY
+
+      actual = "Hello"
+
+      assert_equal expected, actual
+    end
   end
 end

--- a/lib/minitest/difftastic.rb
+++ b/lib/minitest/difftastic.rb
@@ -12,4 +12,12 @@ module Minitest::Difftastic
     left_label: "Expected",
     right_label: "Actual"
   )
+
+  STRING_DIFFER = ::Difftastic::Differ.new(
+    color: :always,
+    tab_width: 2,
+    syntax_highlight: :off,
+    left_label: "Expected (String)",
+    right_label: "Actual (String)"
+  )
 end

--- a/lib/minitest/difftastic/patches/diff.rb
+++ b/lib/minitest/difftastic/patches/diff.rb
@@ -4,7 +4,12 @@ module Minitest::Assertions
   alias minitest_diff diff
 
   def diff(exp, act)
-    ::Minitest::Difftastic::DEFAULT_DIFFER.diff_objects(exp, act)
+    case [exp, act]
+    in [String => exp, String => act] if exp.include?("\n") || act.include?("\n")
+      "\n#{::Minitest::Difftastic::STRING_DIFFER.diff_strings(exp, act)}"
+    else
+      "\n#{::Minitest::Difftastic::DEFAULT_DIFFER.diff_objects(exp, act)}"
+    end
   rescue StandardError => e
     puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
     minitest_diff(exp, act)


### PR DESCRIPTION
This pull request improves the `diff` output when both the `exp` and `act` are `String` objects and one of them contains a newline character.

**Before**: 

![CleanShot 2025-02-06 at 02 40 40@2x](https://github.com/user-attachments/assets/e6ab86e9-3f56-40dc-b2e6-5bb241ee6b02)


**After**:

![CleanShot 2025-02-06 at 02 45 51@2x](https://github.com/user-attachments/assets/2c4ca2be-443a-4e15-b1c2-f75baeaa337a)

