### PR TITLE
Change patches to use prepend instead of alias method

### DIFF
--- a/lib/minitest/difftastic/patches/assert_nil.rb
+++ b/lib/minitest/difftastic/patches/assert_nil.rb
@@ -1,23 +1,26 @@
 # frozen_string_literal: true
 
-module Minitest::Assertions
-  alias minitest_assert_nil assert_nil
+module Difftastic
+  module Patches
+    module AssertNil
+      def assert_nil(obj, msg = nil)
+        msg ||= message(nil, "") {
+          differ = ::Difftastic::Differ.new(
+            color: :always,
+            tab_width: 2,
+            syntax_highlight: :off,
+            left_label: "Expected",
+            right_label: "Actual"
+          )
 
-  def assert_nil(obj, msg = nil)
-    msg ||= message(nil, "") {
-      differ = ::Difftastic::Differ.new(
-        color: :always,
-        tab_width: 2,
-        syntax_highlight: :off,
-        left_label: "Expected",
-        right_label: "Actual"
-      )
+          "\n#{differ.diff_objects(nil, obj)}"
+        }
+        super
+      rescue StandardError
+        super
+      end
 
-      "\n#{differ.diff_objects(nil, obj)}"
-    }
-
-    minitest_assert_nil(obj, msg)
-  rescue StandardError
-    minitest_assert_nil(obj, msg)
+      Minitest::Assertions.prepend(self)
+    end
   end
 end

--- a/lib/minitest/difftastic/patches/assert_operator.rb
+++ b/lib/minitest/difftastic/patches/assert_operator.rb
@@ -1,23 +1,27 @@
 # frozen_string_literal: true
 
-module Minitest::Assertions
-  alias minitest_assert_operator assert_operator
+module Difftastic
+  module Patches
+    module AssertOperator
+      def assert_operator(object1, operator, object2 = UNDEFINED, msg = nil)
+        msg ||= message(nil, "") {
+          differ = ::Difftastic::Differ.new(
+            color: :always,
+            tab_width: 2,
+            syntax_highlight: :off,
+            left_label: "Expected",
+            right_label: "to be #{operator}"
+          )
 
-  def assert_operator(object1, operator, object2 = UNDEFINED, msg = nil)
-    msg ||= message(nil, "") {
-      differ = ::Difftastic::Differ.new(
-        color: :always,
-        tab_width: 2,
-        syntax_highlight: :off,
-        left_label: "Expected",
-        right_label: "to be #{operator}"
-      )
+          "\n#{differ.diff_objects(object1, object2)}"
+        }
 
-      "\n#{differ.diff_objects(object1, object2)}"
-    }
+        super
+      rescue StandardError
+        super
+      end
 
-    minitest_assert_operator(object1, operator, object2, message)
-  rescue StandardError
-    minitest_assert_operator(object1, operator, object2, msg)
+      Minitest::Assertions.prepend(self)
+    end
   end
 end

--- a/lib/minitest/difftastic/patches/assert_predicate.rb
+++ b/lib/minitest/difftastic/patches/assert_predicate.rb
@@ -1,38 +1,42 @@
 # frozen_string_literal: true
 
-module Minitest::Assertions
-  alias minitest_assert_predicate assert_predicate
+module Difftastic
+  module Patches
+    module AssertPredicate
+      def assert_predicate(object, predicate, msg = nil)
+        msg ||= message(nil, "") {
+          pretty = Difftastic.pretty(object)
 
-  def assert_predicate(object, predicate, msg = nil)
-    msg ||= message(nil, "") {
-      pretty = Difftastic.pretty(object)
+          expected = <<~RUBY
+            #{pretty}.#{predicate}
 
-      expected = <<~RUBY
-        #{pretty}.#{predicate}
+            # => true
+          RUBY
 
-        # => true
-      RUBY
+          actual = <<~RUBY
+            #{pretty}.#{predicate}
 
-      actual = <<~RUBY
-        #{pretty}.#{predicate}
+            # => false
+          RUBY
 
-        # => false
-      RUBY
+          differ = ::Difftastic::Differ.new(
+            color: :always,
+            tab_width: 2,
+            syntax_highlight: :on,
+            left_label: "Expected",
+            right_label: "Actual",
+            context: expected.lines.count
+          )
 
-      differ = ::Difftastic::Differ.new(
-        color: :always,
-        tab_width: 2,
-        syntax_highlight: :on,
-        left_label: "Expected",
-        right_label: "Actual",
-        context: expected.lines.count
-      )
+          "\n#{differ.diff_ruby(expected, actual)}"
+        }
 
-      "\n#{differ.diff_ruby(expected, actual)}"
-    }
+        super
+      rescue StandardError
+        super
+      end
 
-    minitest_assert_predicate(object, predicate, msg)
-  rescue StandardError
-    minitest_assert_predicate(object, predicate, msg)
+      Minitest::Assertions.prepend(self)
+    end
   end
 end

--- a/lib/minitest/difftastic/patches/diff.rb
+++ b/lib/minitest/difftastic/patches/diff.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
-module Minitest::Assertions
-  alias minitest_diff diff
+module Difftastic
+  module Patches
+    module Diff
+      def diff(exp, act)
+        case [exp, act]
+        in [String => exp, String => act] if exp.include?("\n") || act.include?("\n")
+          "\n#{::Minitest::Difftastic::STRING_DIFFER.diff_strings(exp, act)}"
+        else
+          "\n#{::Minitest::Difftastic::DEFAULT_DIFFER.diff_objects(exp, act)}"
+        end
+      rescue StandardError => e
+        puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
+        super
+      end
 
-  def diff(exp, act)
-    case [exp, act]
-    in [String => exp, String => act] if exp.include?("\n") || act.include?("\n")
-      "\n#{::Minitest::Difftastic::STRING_DIFFER.diff_strings(exp, act)}"
-    else
-      "\n#{::Minitest::Difftastic::DEFAULT_DIFFER.diff_objects(exp, act)}"
+      Minitest::Assertions.prepend(self)
     end
-  rescue StandardError => e
-    puts "Minitest::Difftastic error: #{e.inspect} (#{e.backtrace[0]})"
-    minitest_diff(exp, act)
   end
 end


### PR DESCRIPTION
Using `prepend` to change behaviour is much safer (and faster) than using `alias_method` to do it. We can still let the original method run by calling `super` and it will pass the parameters to the method automatically as well.