### PR TITLE
Update `difftastic` to `~> 0.6`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,18 @@ PATH
   remote: .
   specs:
     minitest-difftastic (0.1.2)
-      difftastic (~> 0.2)
+      difftastic (~> 0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    difftastic (0.2.0-arm64-darwin)
-    difftastic (0.2.0-x86_64-linux)
+    difftastic (0.6.0-arm64-darwin)
+      pretty_please
+    difftastic (0.6.0-x86_64-linux)
+      pretty_please
+    dispersion (0.2.0)
+      prism
     json (2.9.1)
     language_server-protocol (3.17.0.3)
     minitest (5.25.4)
@@ -17,6 +21,9 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pretty_please (0.2.0)
+      dispersion (~> 0.2)
+    prism (1.3.0)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)

--- a/minitest-difftastic.gemspec
+++ b/minitest-difftastic.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "difftastic", "~> 0.2"
+  spec.add_dependency "difftastic", "~> 0.6"
 end


### PR DESCRIPTION
This pull request updates `difftastic` to `~> 0.6` and `pretty_please` to `~> 0.2` so avoid the crashes we fixed in https://github.com/joeldrapper/pretty_please/pull/21 and to be able to pretty print `ActiveRecord::Base` objects (https://github.com/joeldrapper/pretty_please/pull/23).