### PR TITLE
Properly reference `UNDEFINED` constant in `assert_operator`

### DIFF
--- a/examples/assert_operator.rb
+++ b/examples/assert_operator.rb
@@ -19,5 +19,9 @@ module Examples
     def test_operator_lt
       assert_operator 1, :>, 2
     end
+
+    def test_predicate_operator
+      assert_operator [1, 2, 3], :empty?
+    end
   end
 end

--- a/lib/minitest/difftastic/patches/assert_operator.rb
+++ b/lib/minitest/difftastic/patches/assert_operator.rb
@@ -3,7 +3,7 @@
 module Difftastic
   module Patches
     module AssertOperator
-      def assert_operator(object1, operator, object2 = UNDEFINED, msg = nil)
+      def assert_operator(object1, operator, object2 = Minitest::Assertions::UNDEFINED, msg = nil)
         msg ||= message(nil, "") {
           differ = ::Difftastic::Differ.new(
             color: :always,


### PR DESCRIPTION
Follow-up for https://github.com/marcoroth/minitest-difftastic/pull/13

Referencing `UNDEFINED` worked when it used to be a patch but now since it's a module we need to specify proper constant namespaces. Otherwise `assert_operator` with only two arguments (supposed to work like `assert_predicate`) fails with (from the added example):
```
Examples::AssertOperator#test_predicate_operator:
NameError: uninitialized constant Difftastic::Patches::AssertOperator::UNDEFINED
    examples/assert_operator.rb:24:in `test_predicate_operator'
```




### Unrelated

I think the output in this case is not as useful, but perhaps people should prefer `assert_predicate` anyway. The aim of this PR is to ensure it doesn't fail.
<img width="552" alt="image" src="https://github.com/user-attachments/assets/0f21fe79-7c2d-4b81-9566-fc42424e4e74" />


### CI

I wonder if we should consider adding `rake examples` execution to CI and disallow merges if some of the tests fail with `error` instead of a `failure` (which is expected from an example) 